### PR TITLE
fix: reset rate limit state when switching between accounts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -601,8 +601,14 @@ function createCustomFetch(getAuth: () => Promise<any>, client: any) {
         });
         auth.access = fresh.access;
       } catch {
-        const kc = await readClaudeCodeCredentials();
+        let kc = await readClaudeCodeCredentials();
+        // If CLI credentials are also expired, trigger a CLI refresh
+        if (!kc || isExpiringSoon(kc.expires)) {
+          kc = await refreshViaClaudeCli();
+        }
         if (kc && !isExpiringSoon(kc.expires)) {
+          refreshInFlight = null;
+          currentRefreshToken = kc.refresh;
           await client.auth.set({
             path: { id: "anthropic" },
             body: { type: "oauth", ...kc },
@@ -718,18 +724,26 @@ function createCustomFetch(getAuth: () => Promise<any>, client: any) {
       headers: reqHeaders,
     });
 
-    // On rate limit (429), check if the user switched accounts (CLI or CCS).
-    // If different credentials are found, update auth store and retry once.
-    if (response.status === 429) {
-      const altCreds = await findAlternateCredentials(auth.refresh);
-      if (altCreds) {
+    // On rate limit (429) or expired token (401), attempt recovery and retry once.
+    if (response.status === 429 || response.status === 401) {
+      let freshCreds: OAuthTokens | null = null;
+
+      // Check if the user switched accounts (CLI or CCS)
+      freshCreds = await findAlternateCredentials(auth.refresh);
+
+      // If no alternate account found, force a CLI refresh (handles expired tokens)
+      if (!freshCreds && response.status === 401) {
+        freshCreds = await refreshViaClaudeCli();
+      }
+
+      if (freshCreds && !isExpiringSoon(freshCreds.expires)) {
         refreshInFlight = null;
-        currentRefreshToken = altCreds.refresh;
+        currentRefreshToken = freshCreds.refresh;
         await client.auth.set({
           path: { id: "anthropic" },
-          body: { type: "oauth", ...altCreds },
+          body: { type: "oauth", ...freshCreds },
         });
-        reqHeaders.set("authorization", `Bearer ${altCreds.access}`);
+        reqHeaders.set("authorization", `Bearer ${freshCreds.access}`);
         response = await fetch(reqInput, {
           ...requestInit,
           body,


### PR DESCRIPTION
## Problem

**Account switch not detected after rate limit:**
When a user hits the rate limit on one account and switches to a different account (e.g. via `claude` CLI re-login), the plugin keeps using the previous account's tokens because OpenCode's `getAuth()` returns cached credentials. The user sees "This request would exceed your account's rate limit" even on the new account.

**Expired tokens not auto-refreshed:**
When OAuth tokens expire and both `refreshTokensSafe()` and the CLI credential file have stale tokens, the plugin fails silently — forcing users to manually run `claude` in the terminal to refresh.

## Fix

### Account switch detection
- Tracks the active account via `currentRefreshToken`
- Clears `refreshInFlight` on account switch to prevent token cross-contamination
- On 429 responses, re-reads credentials from all sources (main CLI + CCS instances via `findAlternateCredentials`) and retries with new credentials
- Resets state in `loader` when auth method changes

### Expired token auto-recovery
- Pre-request: falls back to `refreshViaClaudeCli()` when stored credentials are also expired
- Post-request: on 401 (expired token), forces a CLI-driven refresh and retries automatically
- Single retry, no loops

## Changes

- `src/index.ts`: 3 commits — account switch detection, CCS support for alternate credential lookup, and expired token CLI fallback