### PR TITLE
feat: warn when claude cli is outdated, enable logging by default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from "@opencode-ai/plugin";
 import { log } from "./logger.ts";
-import { startIntro, getIntro, awaitIntro } from "./introspection.ts";
+import { startIntro, getIntro, awaitIntro, getLatestCliVersion } from "./introspection.ts";
 import { createAuthorizationRequest, exchangeCodeForTokens } from "./pkce.ts";
 import {
   getCurrentRefreshToken,
@@ -79,9 +79,14 @@ const plugin: Plugin = async ({ client }) => {
               };
             }
 
+            const latestVersion = getLatestCliVersion();
+            const versionWarning = latestVersion
+              ? `\n\n⚠️  Claude CLI is outdated (${getIntro().version} → ${latestVersion}). Run:\n  npm install -g @anthropic-ai/claude-code`
+              : "";
+
             return {
               url: "https://claude.ai",
-              instructions: "Detecting Claude Code credentials...",
+              instructions: `Detecting Claude Code credentials...${versionWarning}`,
               method: "auto" as const,
               async callback() {
                 let tokens = await readClaudeCodeCredentials();

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -234,6 +234,40 @@ async function introspectClaudeBinary(): Promise<IntrospectionResult | null> {
   }
 }
 
+const NPM_REGISTRY_URL = "https://registry.npmjs.org/@anthropic-ai/claude-code/latest";
+
+function compareVersions(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] || 0) - (pb[i] || 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+async function checkForCliUpdate(currentVersion: string): Promise<string | null> {
+  try {
+    const res = await fetch(NPM_REGISTRY_URL, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { version: string };
+    if (!data.version) return null;
+    if (compareVersions(currentVersion, data.version) < 0) {
+      log.warn("Claude CLI is outdated", {
+        current: currentVersion,
+        latest: data.version,
+      });
+      return data.version;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 let _intro: IntrospectionResult = {
   version: DEFAULT_VERSION,
   userAgent: `claude-cli/${DEFAULT_VERSION} (external, cli)`,
@@ -241,9 +275,14 @@ let _intro: IntrospectionResult = {
   scopes: DEFAULT_SCOPES,
 };
 let _introPromise: Promise<void> | null = null;
+let _latestCliVersion: string | null = null;
 
 export function getIntro(): IntrospectionResult {
   return _intro;
+}
+
+export function getLatestCliVersion(): string | null {
+  return _latestCliVersion;
 }
 
 export async function awaitIntro(): Promise<IntrospectionResult> {
@@ -253,8 +292,9 @@ export async function awaitIntro(): Promise<IntrospectionResult> {
 
 export function startIntro(): void {
   _introPromise = introspectClaudeBinary()
-    .then((result) => {
+    .then(async (result) => {
       if (result) _intro = result;
+      _latestCliVersion = await checkForCliUpdate(_intro.version);
     })
     .catch((e) => {
       log.error("Background introspection failed", { error: String(e) });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,7 +2,7 @@ import { appendFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
-const DEBUG = process.env.CLAUDE_AUTH_DEBUG === "1" || process.env.CLAUDE_AUTH_DEBUG === "true";
+const DEBUG = process.env.CLAUDE_AUTH_DEBUG !== "0" && process.env.CLAUDE_AUTH_DEBUG !== "false";
 
 const LOG_DIR = join(homedir(), ".local", "share", "opencode");
 const LOG_FILE = join(LOG_DIR, "claude-auth-debug.log");

--- a/tests/introspection.test.ts
+++ b/tests/introspection.test.ts
@@ -137,6 +137,42 @@ describe("parseVersion", () => {
   });
 });
 
+function compareVersions(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] || 0) - (pb[i] || 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+describe("compareVersions", () => {
+  it("returns 0 for equal versions", () => {
+    expect(compareVersions("2.1.80", "2.1.80")).toBe(0);
+  });
+
+  it("returns negative when first is older", () => {
+    expect(compareVersions("2.1.80", "2.2.0")).toBeLessThan(0);
+  });
+
+  it("returns positive when first is newer", () => {
+    expect(compareVersions("3.0.0", "2.9.99")).toBeGreaterThan(0);
+  });
+
+  it("compares major version correctly", () => {
+    expect(compareVersions("1.9.9", "2.0.0")).toBeLessThan(0);
+  });
+
+  it("compares minor version correctly", () => {
+    expect(compareVersions("2.1.80", "2.2.0")).toBeLessThan(0);
+  });
+
+  it("compares patch version correctly", () => {
+    expect(compareVersions("2.1.79", "2.1.80")).toBeLessThan(0);
+  });
+});
+
 describe("context-1m filtering", () => {
   const LONG_CONTEXT_BETAS = ["context-1m-2025-08-07", "interleaved-thinking-2025-05-14"];
 


### PR DESCRIPTION
Checks npm registry for latest @anthropic-ai/claude-code version during startup. Shows a warning in auth instructions when the local CLI is behind. Logging is now on by default so debug logs are available when users report issues — can be disabled with CLAUDE_AUTH_DEBUG=0.