### PR TITLE
fix: preserve OpenCode identity in prompts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -198,7 +198,8 @@ const plugin: Plugin = async ({ client }) => {
       output: { system: string[] },
     ) => {
       if (input.model?.providerID !== "anthropic") return;
-      const prefix = "You are Claude Code, Anthropic's official CLI for Claude.";
+      const prefix =
+        "You are running inside OpenCode, not Claude Code. Use the tools and capabilities exposed by OpenCode in this session, and do not assume Claude Code-specific tool limitations unless they are explicitly present here.";
       if (output.system.length > 0) {
         output.system.unshift(prefix);
       }

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -14,10 +14,7 @@ export function transformRequestBody(rawBody: string): ParsedBody {
     if (parsed.system && Array.isArray(parsed.system)) {
       parsed.system = parsed.system.map((item: { type?: string; text?: string }) => {
         if (item.type === "text" && item.text) {
-          return {
-            ...item,
-            text: item.text.replace(/OpenCode/g, "Claude Code").replace(/opencode/gi, "Claude"),
-          };
+          return item;
         }
         return item;
       });

--- a/tests/transforms.test.ts
+++ b/tests/transforms.test.ts
@@ -34,7 +34,7 @@ describe("transformRequestBody", () => {
     expect(parsed.messages[0].content[0].name).toBe("mcp_bash");
   });
 
-  it("replaces OpenCode with Claude Code in system prompts", () => {
+  it("preserves OpenCode identity in system prompts", () => {
     const input = JSON.stringify({
       model: "claude-sonnet-4-20250514",
       system: [{ type: "text", text: "You are OpenCode assistant." }],
@@ -43,7 +43,7 @@ describe("transformRequestBody", () => {
     const { body } = transformRequestBody(input);
     const parsed = JSON.parse(body);
 
-    expect(parsed.system[0].text).toBe("You are Claude Code assistant.");
+    expect(parsed.system[0].text).toBe("You are OpenCode assistant.");
   });
 
   it("returns raw body and null modelId on invalid JSON", () => {


### PR DESCRIPTION
## Summary

Fixes #11.

This PR preserves OpenCode identity instead of rewriting prompts to Claude Code.

## What changed

- preserve `OpenCode` wording in transformed system prompts
- replace the Claude Code identity prefix with an OpenCode-specific runtime prefix
- update the transform test to assert OpenCode identity is preserved

## Why

The plugin currently makes Anthropic models think they are running inside Claude Code rather than OpenCode.

That can lead to incorrect behavior around tools and MCP availability, because the model reasons from the wrong host environment.

## Validation

- `bun test` ✅
- `bun run build` ✅
