### PR TITLE
fix: handle multiple OAuth callback formats in browser auth

### DIFF
--- a/src/pkce.ts
+++ b/src/pkce.ts
@@ -29,13 +29,49 @@ export function createAuthorizationRequest(scopes: string) {
   return { url: `${AUTHORIZE_URL}?${params}`, verifier };
 }
 
+/**
+ * Parse an OAuth callback input that may arrive in several formats:
+ *
+ *  1. Full callback URL  — https://platform.claude.com/oauth/code/callback?code=ABC&state=XYZ
+ *  2. Query string        — code=ABC&state=XYZ
+ *  3. Hash-separated      — ABC#XYZ   (legacy format)
+ *  4. Plain code          — ABC
+ *
+ * Returns only the authorization code portion, trimmed.
+ */
+export function parseCallbackCode(raw: string): string {
+  const trimmed = raw.trim();
+
+  // 1. Full URL with query parameters
+  try {
+    const url = new URL(trimmed);
+    const code = url.searchParams.get("code");
+    if (code) return code;
+  } catch {
+    // Not a valid URL — fall through to other formats.
+  }
+
+  // 2. Query-string (code=...&state=...)
+  if (trimmed.includes("=")) {
+    const params = new URLSearchParams(trimmed);
+    const code = params.get("code");
+    if (code) return code;
+  }
+
+  // 3. Hash-separated (code#state)
+  const hashIdx = trimmed.indexOf("#");
+  if (hashIdx >= 0) return trimmed.slice(0, hashIdx);
+
+  // 4. Plain authorization code
+  return trimmed;
+}
+
 export async function exchangeCodeForTokens(
   rawCode: string,
   verifier: string,
   userAgent: string,
 ): Promise<OAuthTokens> {
-  const hashIdx = rawCode.indexOf("#");
-  const code = (hashIdx >= 0 ? rawCode.slice(0, hashIdx) : rawCode).trim();
+  const code = parseCallbackCode(rawCode);
   const body = new URLSearchParams({
     grant_type: "authorization_code",
     code,

--- a/tests/pkce.test.ts
+++ b/tests/pkce.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { parseCallbackCode } from "../src/pkce.ts";
+
+describe("parseCallbackCode", () => {
+  it("extracts code from a full callback URL", () => {
+    const input = "https://platform.claude.com/oauth/code/callback?code=abc123&state=xyz";
+
+    expect(parseCallbackCode(input)).toBe("abc123");
+  });
+
+  it("extracts code from a callback URL with extra parameters", () => {
+    const input = "https://platform.claude.com/oauth/code/callback?code=abc123&state=xyz&foo=bar";
+
+    expect(parseCallbackCode(input)).toBe("abc123");
+  });
+
+  it("extracts code from a query string without URL", () => {
+    expect(parseCallbackCode("code=abc123&state=xyz")).toBe("abc123");
+  });
+
+  it("extracts code from hash-separated format", () => {
+    expect(parseCallbackCode("abc123#xyz")).toBe("abc123");
+  });
+
+  it("returns plain code as-is", () => {
+    expect(parseCallbackCode("abc123")).toBe("abc123");
+  });
+
+  it("trims whitespace from input", () => {
+    expect(parseCallbackCode("  abc123  ")).toBe("abc123");
+  });
+
+  it("trims whitespace around a full URL", () => {
+    const input = "  https://platform.claude.com/oauth/code/callback?code=abc123&state=xyz  ";
+
+    expect(parseCallbackCode(input)).toBe("abc123");
+  });
+
+  it("handles URL without code parameter by falling through", () => {
+    const input = "https://example.com/callback?state=xyz";
+
+    // No code param in URL, no "=" with code key, no hash — returns trimmed input
+    expect(parseCallbackCode(input)).toBe(input.trim());
+  });
+
+  it("handles empty string", () => {
+    expect(parseCallbackCode("")).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts a `parseCallbackCode()` helper that handles four OAuth callback input formats users may paste during browser auth
- Adds a test suite (`tests/pkce.test.ts`) covering all supported formats

## Problem

When using the "Claude Pro/Max (browser)" auth method, users paste the authorization response into the CLI. Currently, only two formats are recognized:

1. `code#state` (hash-separated)
2. Plain authorization code

However, some users copy the **full redirect URL** from their browser address bar (e.g. `https://platform.claude.com/oauth/code/callback?code=ABC&state=XYZ`) or the query string portion (`code=ABC&state=XYZ`). These fail silently because the code includes the entire URL/query, causing the token exchange to fail.

## Solution

A new `parseCallbackCode()` function tries four formats in order:

| Priority | Format | Example |
|----------|--------|---------|
| 1 | Full callback URL | `https://platform.claude.com/oauth/code/callback?code=ABC&state=XYZ` |
| 2 | Query string | `code=ABC&state=XYZ` |
| 3 | Hash-separated (existing) | `ABC#XYZ` |
| 4 | Plain code | `ABC` |

The existing `exchangeCodeForTokens` signature is unchanged — the parsing is extracted into a separate, exported, tested function.

## Tests

9 test cases covering all formats, edge cases (whitespace, missing params, empty string). All 91 tests pass.

```
bun test v1.3.10
 91 pass
 0 fail
 111 expect() calls
Ran 91 tests across 6 files.
```