### PR TITLE
fix: handle multiple OAuth callback formats in browser auth

### DIFF
--- a/src/pkce.ts
+++ b/src/pkce.ts
@@ -42,27 +42,29 @@ export function createAuthorizationRequest(scopes: string) {
 export function parseCallbackCode(raw: string): string {
   const trimmed = raw.trim();
 
-  // 1. Full URL with query parameters
+  let isUrl = false;
   try {
     const url = new URL(trimmed);
+    isUrl = true;
+    const error = url.searchParams.get("error");
+    if (error) throw new Error(`OAuth error: ${error}`);
     const code = url.searchParams.get("code");
-    if (code) return code;
-  } catch {
-    // Not a valid URL — fall through to other formats.
+    if (code !== null) return code;
+    throw new Error("OAuth callback URL is missing a code parameter");
+  } catch (e) {
+    if (isUrl) throw e;
   }
 
-  // 2. Query-string (code=...&state=...)
   if (trimmed.includes("=")) {
-    const params = new URLSearchParams(trimmed);
+    const defragmented = trimmed.split("#")[0];
+    const params = new URLSearchParams(defragmented);
     const code = params.get("code");
-    if (code) return code;
+    if (code !== null) return code;
   }
 
-  // 3. Hash-separated (code#state)
   const hashIdx = trimmed.indexOf("#");
   if (hashIdx >= 0) return trimmed.slice(0, hashIdx);
 
-  // 4. Plain authorization code
   return trimmed;
 }
 

--- a/src/pkce.ts
+++ b/src/pkce.ts
@@ -29,13 +29,49 @@ export function createAuthorizationRequest(scopes: string) {
   return { url: `${AUTHORIZE_URL}?${params}`, verifier };
 }
 
+/**
+ * Parse an OAuth callback input that may arrive in several formats:
+ *
+ *  1. Full callback URL  — https://platform.claude.com/oauth/code/callback?code=ABC&state=XYZ
+ *  2. Query string        — code=ABC&state=XYZ
+ *  3. Hash-separated      — ABC#XYZ   (legacy format)
+ *  4. Plain code          — ABC
+ *
+ * Returns only the authorization code portion, trimmed.
+ */
+export function parseCallbackCode(raw: string): string {
+  const trimmed = raw.trim();
+
+  // 1. Full URL with query parameters
+  try {
+    const url = new URL(trimmed);
+    const code = url.searchParams.get("code");
+    if (code) return code;
+  } catch {
+    // Not a valid URL — fall through to other formats.
+  }
+
+  // 2. Query-string (code=...&state=...)
+  if (trimmed.includes("=")) {
+    const params = new URLSearchParams(trimmed);
+    const code = params.get("code");
+    if (code) return code;
+  }
+
+  // 3. Hash-separated (code#state)
+  const hashIdx = trimmed.indexOf("#");
+  if (hashIdx >= 0) return trimmed.slice(0, hashIdx);
+
+  // 4. Plain authorization code
+  return trimmed;
+}
+
 export async function exchangeCodeForTokens(
   rawCode: string,
   verifier: string,
   userAgent: string,
 ): Promise<OAuthTokens> {
-  const hashIdx = rawCode.indexOf("#");
-  const code = (hashIdx >= 0 ? rawCode.slice(0, hashIdx) : rawCode).trim();
+  const code = parseCallbackCode(rawCode);
   const body = new URLSearchParams({
     grant_type: "authorization_code",
     code,

--- a/tests/pkce.test.ts
+++ b/tests/pkce.test.ts
@@ -18,6 +18,14 @@ describe("parseCallbackCode", () => {
     expect(parseCallbackCode("code=abc123&state=xyz")).toBe("abc123");
   });
 
+  it("extracts code from a query string with a hash fragment", () => {
+    expect(parseCallbackCode("code=abc123#state=xyz")).toBe("abc123");
+  });
+
+  it("extracts code from a query string with a leading question mark", () => {
+    expect(parseCallbackCode("?code=abc123&state=xyz")).toBe("abc123");
+  });
+
   it("extracts code from hash-separated format", () => {
     expect(parseCallbackCode("abc123#xyz")).toBe("abc123");
   });
@@ -36,11 +44,26 @@ describe("parseCallbackCode", () => {
     expect(parseCallbackCode(input)).toBe("abc123");
   });
 
-  it("handles URL without code parameter by falling through", () => {
-    const input = "https://example.com/callback?state=xyz";
+  it("throws for a URL without a code parameter", () => {
+    expect(() => parseCallbackCode("https://example.com/callback?state=xyz")).toThrow(
+      "OAuth callback URL is missing a code parameter",
+    );
+  });
 
-    // No code param in URL, no "=" with code key, no hash — returns trimmed input
-    expect(parseCallbackCode(input)).toBe(input.trim());
+  it("throws for a URL with an error parameter", () => {
+    expect(() =>
+      parseCallbackCode("https://example.com/callback?error=access_denied&state=xyz"),
+    ).toThrow("OAuth error: access_denied");
+  });
+
+  it("returns empty string for an empty code in a query string", () => {
+    expect(parseCallbackCode("code=&state=xyz")).toBe("");
+  });
+
+  it("returns empty string for an empty code in a URL", () => {
+    expect(
+      parseCallbackCode("https://platform.claude.com/oauth/code/callback?code=&state=xyz"),
+    ).toBe("");
   });
 
   it("handles empty string", () => {

--- a/tests/pkce.test.ts
+++ b/tests/pkce.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { parseCallbackCode } from "../src/pkce.ts";
+
+describe("parseCallbackCode", () => {
+  it("extracts code from a full callback URL", () => {
+    const input = "https://platform.claude.com/oauth/code/callback?code=abc123&state=xyz";
+
+    expect(parseCallbackCode(input)).toBe("abc123");
+  });
+
+  it("extracts code from a callback URL with extra parameters", () => {
+    const input = "https://platform.claude.com/oauth/code/callback?code=abc123&state=xyz&foo=bar";
+
+    expect(parseCallbackCode(input)).toBe("abc123");
+  });
+
+  it("extracts code from a query string without URL", () => {
+    expect(parseCallbackCode("code=abc123&state=xyz")).toBe("abc123");
+  });
+
+  it("extracts code from hash-separated format", () => {
+    expect(parseCallbackCode("abc123#xyz")).toBe("abc123");
+  });
+
+  it("returns plain code as-is", () => {
+    expect(parseCallbackCode("abc123")).toBe("abc123");
+  });
+
+  it("trims whitespace from input", () => {
+    expect(parseCallbackCode("  abc123  ")).toBe("abc123");
+  });
+
+  it("trims whitespace around a full URL", () => {
+    const input = "  https://platform.claude.com/oauth/code/callback?code=abc123&state=xyz  ";
+
+    expect(parseCallbackCode(input)).toBe("abc123");
+  });
+
+  it("handles URL without code parameter by falling through", () => {
+    const input = "https://example.com/callback?state=xyz";
+
+    // No code param in URL, no "=" with code key, no hash — returns trimmed input
+    expect(parseCallbackCode(input)).toBe(input.trim());
+  });
+
+  it("handles empty string", () => {
+    expect(parseCallbackCode("")).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Based on PR #18 by @Steffen025 with review fixes applied.

- Extracts `parseCallbackCode()` helper for four OAuth callback input formats
- Fixes hash+query string interaction bug (`code=abc#state` was not stripped correctly)
- Throws on OAuth error responses instead of silent fallthrough
- Uses `!== null` instead of truthiness for empty code handling
- Adds test suite with 14 cases covering all formats and edge cases

## Original problem

Users copying the full redirect URL from the browser address bar during "Claude Pro/Max (browser)" auth caused silent token exchange failures.

## Changes from original PR

- Strip `#` fragment before `URLSearchParams` parsing (fixes `code=abc#state=xyz` regression)
- Detect and throw on OAuth `?error=` responses
- Throw when a valid URL has no `code` parameter (instead of returning entire URL as code)
- `code !== null` checks for correct empty-code handling
- 5 additional test cases for edge cases

All 96 tests pass, typecheck/build/lint clean.