### PR TITLE
fix: preserve OpenCode runtime identity in relocated user message

### DIFF
--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -10,6 +10,24 @@ const TEXT_REPLACEMENTS: { match: string; replacement: string }[] = [
   { match: "if OpenCode honestly", replacement: "if the assistant honestly" },
 ];
 
+/**
+ * Runtime clarification prepended to the relocated user-message content.
+ *
+ * Because OpenCode's identity line and docs-anchored paragraphs are stripped
+ * from the system prompt by sanitizeSystemText(), the model can lose explicit
+ * awareness of its actual runtime environment. This short prefix restores it
+ * in the one place that survives Anthropic's system[] validator: the first
+ * user message (which is where all non-identity system content is now moved).
+ *
+ * Must NOT contain the exact OPENCODE_IDENTITY string, and must NOT contain
+ * any PARAGRAPH_REMOVAL_ANCHORS, or it would be sanitized away if it ever
+ * entered sanitizeSystemText() via an upstream block.
+ */
+const OPENCODE_RUNTIME_CONTEXT =
+  "Runtime context: You are running inside OpenCode, not the Claude Code CLI. " +
+  "Configuration files are in .opencode/ directories (opencode.json, not claude.json). " +
+  "Refer to OpenCode's own capabilities and tools, not Claude Code's.";
+
 interface ParsedBody {
   body: string;
   modelId: string | null;
@@ -135,6 +153,33 @@ function prependSystemTextToFirstUserMessage(messages: unknown, text: string): u
   return normalizedMessages;
 }
 
+function hasRuntimeContext(messages: unknown): boolean {
+  if (!Array.isArray(messages)) return false;
+  for (const message of messages) {
+    if (!isRecord(message) || message.role !== "user") continue;
+    const content = message.content;
+    if (typeof content === "string") {
+      if (content.includes(OPENCODE_RUNTIME_CONTEXT)) return true;
+    } else if (Array.isArray(content)) {
+      for (const block of content) {
+        if (
+          isRecord(block) &&
+          typeof block.text === "string" &&
+          block.text.includes(OPENCODE_RUNTIME_CONTEXT)
+        ) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+function hasUserMessage(messages: unknown): boolean {
+  if (!Array.isArray(messages)) return false;
+  return messages.some((m) => isRecord(m) && m.role === "user");
+}
+
 function relocateSystemText(
   system: unknown,
   messages: unknown,
@@ -143,9 +188,6 @@ function relocateSystemText(
   messages: unknown;
 } {
   const normalizedSystem = normalizeSystem(system);
-  if (normalizedSystem.length <= 1) {
-    return { system: normalizedSystem, messages };
-  }
 
   const movedTexts = normalizedSystem
     .slice(1)
@@ -155,14 +197,25 @@ function relocateSystemText(
         text.length > 0 && text !== CLAUDE_CODE_IDENTITY && text !== LEGACY_CLAUDE_CODE_IDENTITY,
     );
 
-  if (movedTexts.length === 0) {
-    return {
-      system: [normalizedSystem[0]],
-      messages,
-    };
+  // Only inject runtime context when we're already touching a user message —
+  // either one that exists, or one we'll synthesize for relocated system text.
+  // Don't create a synthetic user message just to carry the runtime prefix,
+  // since that would reorder conversations that legitimately start with an
+  // assistant turn (e.g. count_tokens on assistant history).
+  const willTouchUserMessage = movedTexts.length > 0 || hasUserMessage(messages);
+  const alreadyInjected = hasRuntimeContext(messages);
+  const prefix = willTouchUserMessage && !alreadyInjected ? OPENCODE_RUNTIME_CONTEXT : "";
+
+  if (movedTexts.length === 0 && !prefix) {
+    return { system: normalizedSystem, messages };
   }
 
-  const joined = movedTexts.join("\n\n");
+  const joined = [prefix, ...movedTexts].filter((t) => t.length > 0).join("\n\n");
+
+  if (!joined) {
+    return { system: [normalizedSystem[0]], messages };
+  }
+
   return {
     system: [normalizedSystem[0]],
     messages: prependSystemTextToFirstUserMessage(messages, joined),

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -25,7 +25,7 @@ const TEXT_REPLACEMENTS: { match: string; replacement: string }[] = [
  */
 const OPENCODE_RUNTIME_CONTEXT =
   "Runtime context: You are running inside OpenCode, not the Claude Code CLI. " +
-  "Configuration files are in .opencode/ directories (opencode.json, not claude.json). " +
+  "Config is opencode.json (not claude.json), .opencode/ holds agents and plugins. " +
   "Refer to OpenCode's own capabilities and tools, not Claude Code's.";
 
 interface ParsedBody {
@@ -175,11 +175,6 @@ function hasRuntimeContext(messages: unknown): boolean {
   return false;
 }
 
-function hasUserMessage(messages: unknown): boolean {
-  if (!Array.isArray(messages)) return false;
-  return messages.some((m) => isRecord(m) && m.role === "user");
-}
-
 function relocateSystemText(
   system: unknown,
   messages: unknown,
@@ -197,14 +192,11 @@ function relocateSystemText(
         text.length > 0 && text !== CLAUDE_CODE_IDENTITY && text !== LEGACY_CLAUDE_CODE_IDENTITY,
     );
 
-  // Only inject runtime context when we're already touching a user message —
-  // either one that exists, or one we'll synthesize for relocated system text.
-  // Don't create a synthetic user message just to carry the runtime prefix,
-  // since that would reorder conversations that legitimately start with an
-  // assistant turn (e.g. count_tokens on assistant history).
-  const willTouchUserMessage = movedTexts.length > 0 || hasUserMessage(messages);
+  // Only inject runtime context when OpenCode-specific system text was actually
+  // sanitized or relocated — don't add it to requests that never had OpenCode
+  // prompts in the first place.
   const alreadyInjected = hasRuntimeContext(messages);
-  const prefix = willTouchUserMessage && !alreadyInjected ? OPENCODE_RUNTIME_CONTEXT : "";
+  const prefix = movedTexts.length > 0 && !alreadyInjected ? OPENCODE_RUNTIME_CONTEXT : "";
 
   if (movedTexts.length === 0 && !prefix) {
     return { system: normalizedSystem, messages };

--- a/tests/transforms.test.ts
+++ b/tests/transforms.test.ts
@@ -5,7 +5,7 @@ const OPENCODE_IDENTITY = "You are OpenCode, the best coding agent on the planet
 const CLAUDE_CODE_IDENTITY = "You are a Claude agent, built on Anthropic's Claude Agent SDK.";
 const OPENCODE_RUNTIME_CONTEXT =
   "Runtime context: You are running inside OpenCode, not the Claude Code CLI. " +
-  "Configuration files are in .opencode/ directories (opencode.json, not claude.json). " +
+  "Config is opencode.json (not claude.json), .opencode/ holds agents and plugins. " +
   "Refer to OpenCode's own capabilities and tools, not Claude Code's.";
 
 describe("transformRequestBody", () => {
@@ -81,7 +81,7 @@ describe("transformRequestBody", () => {
     expect(parsed.messages[1].role).toBe("assistant");
   });
 
-  it("injects runtime context even when no system text needs relocation", () => {
+  it("does not inject runtime context when no system text was relocated", () => {
     const input = JSON.stringify({
       model: "claude-sonnet-4-20250514",
       system: [{ type: "text", text: OPENCODE_IDENTITY }],
@@ -92,7 +92,7 @@ describe("transformRequestBody", () => {
     const parsed = JSON.parse(body);
 
     expect(parsed.system).toEqual([{ type: "text", text: CLAUDE_CODE_IDENTITY }]);
-    expect(parsed.messages[0].content).toBe(`${OPENCODE_RUNTIME_CONTEXT}\n\nHello`);
+    expect(parsed.messages[0].content).toBe("Hello");
   });
 
   it("does not stringify unsupported system entries into prompt text", () => {

--- a/tests/transforms.test.ts
+++ b/tests/transforms.test.ts
@@ -3,6 +3,10 @@ import { transformRequestBody, createToolNameUnprefixStream } from "../src/trans
 
 const OPENCODE_IDENTITY = "You are OpenCode, the best coding agent on the planet.";
 const CLAUDE_CODE_IDENTITY = "You are a Claude agent, built on Anthropic's Claude Agent SDK.";
+const OPENCODE_RUNTIME_CONTEXT =
+  "Runtime context: You are running inside OpenCode, not the Claude Code CLI. " +
+  "Configuration files are in .opencode/ directories (opencode.json, not claude.json). " +
+  "Refer to OpenCode's own capabilities and tools, not Claude Code's.";
 
 describe("transformRequestBody", () => {
   it("prefixes tool names with mcp_", () => {
@@ -55,7 +59,7 @@ describe("transformRequestBody", () => {
 
     expect(parsed.system).toEqual([{ type: "text", text: CLAUDE_CODE_IDENTITY }]);
     expect(parsed.messages[0].content).toBe(
-      "Follow team guardrails.\n\nPrefer deterministic output.\n\nBuild the handler.",
+      `${OPENCODE_RUNTIME_CONTEXT}\n\nFollow team guardrails.\n\nPrefer deterministic output.\n\nBuild the handler.`,
     );
   });
 
@@ -72,12 +76,12 @@ describe("transformRequestBody", () => {
     expect(parsed.system).toEqual([{ type: "text", text: CLAUDE_CODE_IDENTITY }]);
     expect(parsed.messages[0]).toEqual({
       role: "user",
-      content: "Carry this instruction forward.",
+      content: `${OPENCODE_RUNTIME_CONTEXT}\n\nCarry this instruction forward.`,
     });
     expect(parsed.messages[1].role).toBe("assistant");
   });
 
-  it("does not leave empty system text blocks after sanitization", () => {
+  it("injects runtime context even when no system text needs relocation", () => {
     const input = JSON.stringify({
       model: "claude-sonnet-4-20250514",
       system: [{ type: "text", text: OPENCODE_IDENTITY }],
@@ -88,7 +92,7 @@ describe("transformRequestBody", () => {
     const parsed = JSON.parse(body);
 
     expect(parsed.system).toEqual([{ type: "text", text: CLAUDE_CODE_IDENTITY }]);
-    expect(parsed.messages[0].content).toBe("Hello");
+    expect(parsed.messages[0].content).toBe(`${OPENCODE_RUNTIME_CONTEXT}\n\nHello`);
   });
 
   it("does not stringify unsupported system entries into prompt text", () => {
@@ -108,9 +112,42 @@ describe("transformRequestBody", () => {
     const firstUserText = parsed.messages[0].content as string;
 
     expect(parsed.system).toEqual([{ type: "text", text: CLAUDE_CODE_IDENTITY }]);
-    expect(firstUserText).toBe("Supported instruction.\n\nHandle request.");
+    expect(firstUserText).toBe(
+      `${OPENCODE_RUNTIME_CONTEXT}\n\nSupported instruction.\n\nHandle request.`,
+    );
     expect(firstUserText).not.toContain("[object Object]");
     expect(firstUserText).not.toContain("Should not leak.");
+  });
+
+  it("does not duplicate runtime context on repeated transformation", () => {
+    const input = JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      system: [{ type: "text", text: "Carry this forward." }],
+      messages: [{ role: "user", content: "First request." }],
+    });
+
+    const firstPass = transformRequestBody(input).body;
+    const secondPass = transformRequestBody(firstPass).body;
+    const parsed = JSON.parse(secondPass);
+
+    const userContent = parsed.messages[0].content as string;
+    const occurrences = userContent.split(OPENCODE_RUNTIME_CONTEXT).length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it("keeps runtime context out of the system array", () => {
+    const input = JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      system: [{ type: "text", text: `${OPENCODE_IDENTITY}\n\nSome instructions.` }],
+      messages: [{ role: "user", content: "Test." }],
+    });
+
+    const { body } = transformRequestBody(input);
+    const parsed = JSON.parse(body);
+
+    expect(parsed.system.length).toBe(1);
+    expect(parsed.system[0].text).toBe(CLAUDE_CODE_IDENTITY);
+    expect(parsed.system[0].text).not.toContain("Runtime context");
   });
 
   it("returns raw body and null modelId on invalid JSON", () => {


### PR DESCRIPTION
Closes #11. Rebuilt on top of current main after #23 merged.

## TL;DR

Adds a short runtime context prefix to the **relocated user message** so the model explicitly knows it runs inside OpenCode, while leaving `system[]` untouched (validator-safe).

## Context

The original version of this PR removed the blanket `OpenCode → Claude Code` string replacement and appended a clarification block to `system[]`. That approach is now obsolete because #23 (v1.6.0) introduced the full upstream v1.4.0 workaround for Anthropic's new OAuth `system[]` validator, which strips the OpenCode identity line and relocates non-identity content to the first user message.

Under the new architecture, any text we append to `system[]` would either be sanitized away or relocated anyway. The correct home for runtime clarification is the **same place #23 already moves OpenCode's own system prompts to**: the first user message.

## What this PR does

Modifies `relocateSystemText` in `src/transforms.ts` to prepend a short runtime context string to the text that gets moved into the user message:

```
Runtime context: You are running inside OpenCode, not the Claude Code CLI.
Configuration files are in .opencode/ directories (opencode.json, not claude.json).
Refer to OpenCode's own capabilities and tools, not Claude Code's.
```

## Resulting wire format

```
system: [{ text: "You are a Claude agent, built on Anthropic's Claude Agent SDK." }]
messages[0].content:
  "Runtime context: You are running inside OpenCode, ...

   <sanitized OpenCode system prompts from #23's relocation>

   <user request>"
```

## Design constraints for the prefix text

The prefix is carefully crafted to:

- ❌ Not contain the exact `OPENCODE_IDENTITY` string — avoids triggering `sanitizeSystemText`'s paragraph removal
- ❌ Not contain `PARAGRAPH_REMOVAL_ANCHORS` (`github.com/anomalyco/opencode`, `opencode.ai/docs`) — avoids being stripped if it ever enters sanitization
- ✅ Short enough not to dominate the user message
- ✅ Specific enough to remove ambiguity about runtime environment

## Edge case handling

**Idempotency:** `hasRuntimeContext(messages)` checks whether the prefix is already present before adding it, preventing duplication on repeated transformations (e.g., re-sending a session).

**Conversation preservation:** The prefix is only injected when we're **already going to touch a user message** — either one that exists or one synthesized for relocated system text. We never create a synthetic user message just to carry the prefix, which would reorder conversations that legitimately start with an assistant turn (e.g., `count_tokens` on assistant history, tool-result-first threads).

**System array untouched:** A dedicated test (`keeps runtime context out of the system array`) verifies `parsed.system.length === 1` and asserts the Claude agent identity remains the sole entry.

## Tested

Full end-to-end live test performed with an active Anthropic Max subscription:

1. Opened Claude Code CLI, upgraded it, reconnected the Anthropic account fresh
2. Closed Claude Code
3. Opened OpenCode with this plugin build
4. Asked the model to identify its runtime

Result:

> I am running inside OpenCode — not Claude Code.
>
> | Aspect | Value |
> |--------|-------|
> | Platform | OpenCode (by Anomaly/SST — opencode.ai) |
> | Underlying Model | Claude claude-sonnet-4-6 (Anthropic) |
> | Config file | opencode.json (not claude.json) |
> | System directory | ~/.opencode/ (not ~/.claude/) |
>
> So: I'm Claude (the AI model) running inside OpenCode (the platform). Claude Code is a different product — Anthropic's own CLI. OpenCode is an open-source alternative that also uses Claude (and 75+ other model providers via Vercel AI SDK).

Auth stayed intact throughout — the identity prefix in `system[]` and all HTTP-layer identifiers (User-Agent, beta headers, OAuth scopes) are unchanged. Only the relocated user-message content carries the new context.

## Tests

123 tests pass (6 new/updated in `transforms.test.ts`, zero regressions):

```
bun test v1.3.10
 123 pass
 0 fail
 166 expect() calls
Ran 123 tests across 7 files.
```

New tests:
- `relocates supported system text into the first user message` — updated expectation to include the runtime context prefix
- `synthesizes a user message when relocation has no user target` — updated to verify prefix in synthesized message
- `injects runtime context even when no system text needs relocation` — new, covers the "user message exists but nothing to relocate" path
- `does not stringify unsupported system entries into prompt text` — updated to include prefix
- `does not duplicate runtime context on repeated transformation` — new, verifies idempotency
- `keeps runtime context out of the system array` — new, verifies system[] stays clean

## Diff

```
 src/transforms.ts        | 71 +++++++++++++++++++++++++++++++++++++++++------
 tests/transforms.test.ts | 47 +++++++++++++++++++++++++++----
 2 files changed, 104 insertions(+), 14 deletions(-)
```