### PR TITLE
fix: use independent state and verifier for PKCE (RFC 7636)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ const plugin: Plugin = async ({ client }) => {
           label: "Claude Pro/Max (browser)",
           async authorize() {
             const { scopes } = await awaitIntro();
-            const { url, verifier } = createAuthorizationRequest(scopes);
+            const { url, verifier, state } = createAuthorizationRequest(scopes);
             let exchangePromise: Promise<any> | null = null;
             return {
               url,
@@ -167,6 +167,7 @@ const plugin: Plugin = async ({ client }) => {
                     const tokens = await exchangeCodeForTokens(
                       code,
                       verifier,
+                      state,
                       getIntro().userAgent,
                     );
                     return { type: "success" as const, ...tokens };

--- a/src/pkce.ts
+++ b/src/pkce.ts
@@ -15,6 +15,7 @@ function base64url(buf: Buffer): string {
 
 export function createAuthorizationRequest(scopes: string) {
   const verifier = base64url(randomBytes(32));
+  const state = base64url(randomBytes(32));
   const challenge = base64url(createHash("sha256").update(verifier).digest());
   const params = new URLSearchParams({
     code: "true",
@@ -24,9 +25,9 @@ export function createAuthorizationRequest(scopes: string) {
     scope: scopes,
     code_challenge: challenge,
     code_challenge_method: "S256",
-    state: verifier,
+    state,
   });
-  return { url: `${AUTHORIZE_URL}?${params}`, verifier };
+  return { url: `${AUTHORIZE_URL}?${params}`, verifier, state };
 }
 
 /**
@@ -71,6 +72,7 @@ export function parseCallbackCode(raw: string): string {
 export async function exchangeCodeForTokens(
   rawCode: string,
   verifier: string,
+  state: string,
   userAgent: string,
 ): Promise<OAuthTokens> {
   const code = parseCallbackCode(rawCode);
@@ -80,7 +82,7 @@ export async function exchangeCodeForTokens(
     code_verifier: verifier,
     client_id: CLIENT_ID,
     redirect_uri: REDIRECT_URI,
-    state: verifier,
+    state,
   });
 
   log.info("Exchanging authorization code for tokens");

--- a/tests/pkce.test.ts
+++ b/tests/pkce.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { parseCallbackCode } from "../src/pkce.ts";
+import { createAuthorizationRequest, parseCallbackCode } from "../src/pkce.ts";
 
 describe("parseCallbackCode", () => {
   it("extracts code from a full callback URL", () => {
@@ -68,5 +68,28 @@ describe("parseCallbackCode", () => {
 
   it("handles empty string", () => {
     expect(parseCallbackCode("")).toBe("");
+  });
+});
+
+describe("createAuthorizationRequest", () => {
+  it("generates independent state and verifier values", () => {
+    const { verifier, state } = createAuthorizationRequest("user:inference");
+
+    expect(verifier).toBeDefined();
+    expect(state).toBeDefined();
+    expect(verifier).not.toBe(state);
+  });
+
+  it("includes state in the authorization URL", () => {
+    const { url, state } = createAuthorizationRequest("user:inference");
+
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get("state")).toBe(state);
+  });
+
+  it("does not include verifier in the authorization URL", () => {
+    const { url, verifier } = createAuthorizationRequest("user:inference");
+
+    expect(url).not.toContain(verifier);
   });
 });


### PR DESCRIPTION
Fixes #16.

## Problem

`createAuthorizationRequest` reuses the PKCE `code_verifier` as the OAuth `state` parameter. Per RFC 7636 and RFC 6749 these serve different purposes:

| Parameter | Purpose | Visibility |
|-----------|---------|------------|
| `state` | CSRF protection | Visible in authorization URL and redirect callback |
| `code_verifier` | Proof of possession | Never leaves the client until token exchange |

Reusing the same value means observing the `state` (browser history, proxy logs, shoulder surfing) also reveals the `code_verifier`, weakening the PKCE guarantee.

## Fix

Generate a separate `base64url(randomBytes(32))` for `state`:

```diff
  const verifier = base64url(randomBytes(32));
+ const state = base64url(randomBytes(32));
```

`createAuthorizationRequest` now returns `{ url, verifier, state }`, and `exchangeCodeForTokens` accepts `state` as a separate parameter.

## Changes

| File | What |
|------|------|
| `src/pkce.ts` | Separate `state` generation, added `state` parameter to `exchangeCodeForTokens` |
| `src/index.ts` | Destructure and pass `state` through the auth flow |
| `tests/pkce.test.ts` | 3 new tests: independence, URL inclusion, verifier not exposed in URL |

## Tests

124 tests pass:

```
bun test v1.3.10
 124 pass
 0 fail
 167 expect() calls
```